### PR TITLE
php7 compatibility for throwable different then Exception

### DIFF
--- a/src/BugsnagComponent.php
+++ b/src/BugsnagComponent.php
@@ -122,7 +122,7 @@ class BugsnagComponent extends \yii\base\Component
         $this->getClient()->notifyError($category, $message, ['trace' => $trace], 'info');
     }
 
-    public function notifyException(\Exception $exception, $severity = null)
+    public function notifyException($exception, $severity = null)
     {
         $metadata = null;
         if ($exception instanceof BugsnagCustomMetadataInterface)


### PR DESCRIPTION
> the Error hierarchy does not inherit from Exception ( http://php.net/manual/ru/language.errors.php7.php )

so when catching `ParseError` (for example `syntax error, unexpected 'class' (T_CLASS)` ) the php wouldn't throw `Exception` and instead will throw an `Error`.